### PR TITLE
Allow Systems that are at or above the current version

### DIFF
--- a/check-10.14-mojave-compatibility.py
+++ b/check-10.14-mojave-compatibility.py
@@ -98,8 +98,8 @@ def is_system_version_supported():
     if StrictVersion(product_version) >= StrictVersion('10.14'):
         logger("System",
                "%s %s" % (product_name, product_version),
-               "Failed")
-        return False
+               "OK")
+        return True
     elif StrictVersion(product_version) >= StrictVersion('10.8'):
         logger("System",
                "%s %s" % (product_name, product_version),


### PR DESCRIPTION
It seemed odd that the script would prevent the current version from running, however, I don't know every environment that these scripts are used in.

Testing on 10.14.2 and creating a 10.14.3 install DMG worked as expected.